### PR TITLE
Make continuous data read more power efficient

### DIFF
--- a/src/ads1292/mod.rs
+++ b/src/ads1292/mod.rs
@@ -51,12 +51,18 @@ where
     }
 
     /// Read a single data block without sending the RDATA command first
-    /// To be used in RDATAC mode
+    /// To be used in RDATAC mode.
+    /// WARNING: This function retrieves ecg data more power efficiently by avoiding the delays
+    /// that are usually necessary when communicating with the ADS1292 device. Use a delay of at
+    /// least 50 microseconds between retrieving samples and between retrieving a sample and
+    /// sending any other command, register read or register write.
     pub fn read(&mut self) -> Result<Ads1292Data, E, EO> {
         let mut buf = [0u8; 9];
 
         // Receive data
-        self.spi.transfer(&mut buf).map_err(|e| e.into())?;
+        unsafe {
+            self.spi.unsafe_transfer(&mut buf).map_err(|e| e.into())?;
+        }
         Ok(buf.into())
     }
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -57,7 +57,19 @@ where
         })();
         self.ncs.set_high().map_err(SpiError::NCSError)?;
         self.wait(10)?;
+        res?; // Drop out of function with SPIError only after setting NCS.
+        Ok(())
+    }
 
+    /// Transfer the buffer to the device, the passed buffer will contain the read data.
+    /// WARNING: This function runs spi transfers more power efficiently by avoiding the delays
+    /// that are usually necessary when communicating with the ADS1292 device. Use a delay of at
+    /// least 50 microseconds between uses of this and other spi transfer and write functions.
+    #[inline]
+    pub unsafe fn unsafe_transfer(&mut self, buffer: &mut [u8]) -> Result<(), SpiError<E, EO>> {
+        self.ncs.set_low().map_err(SpiError::NCSError)?;
+        let res = self.spi.transfer(buffer);
+        self.ncs.set_high().map_err(SpiError::NCSError)?;
         res?; // Drop out of function with SPIError only after setting NCS.
         Ok(())
     }


### PR DESCRIPTION
Implement power saving by removing the transfer delays for continuous data reads, which should not need them in normal usage. Warning in documentation included.