### PR TITLE
Clean up unreachable errors

### DIFF
--- a/src/ads1292/data_stream.rs
+++ b/src/ads1292/data_stream.rs
@@ -7,41 +7,41 @@ use crate::ads1292::Ads1292;
 use crate::{Command, Result, Ads129xx};
 
 /// Ads1292 Data stream. Used to read data continuously.
-pub struct Ads1292DataStream<SPI, NCS, TIM, E, EO>
+pub struct Ads1292DataStream<SPI, NCS, TIM, E>
 where
     SPI: bspi::Transfer<u8, Error = E> + bspi::Write<u8, Error = E>,
-    NCS: OutputPin<Error = EO>,
+    NCS: OutputPin<Error = core::convert::Infallible>,
     TIM: CountDown,
 {
     ads1292: Ads1292<SPI, NCS, TIM>,
 }
 
-impl<SPI, NCS, TIM, E, EO> Ads1292DataStream<SPI, NCS, TIM, E, EO>
+impl<SPI, NCS, TIM, E> Ads1292DataStream<SPI, NCS, TIM, E>
 where
     SPI: bspi::Transfer<u8, Error = E> + bspi::Write<u8, Error = E>,
-    NCS: OutputPin<Error = EO>,
+    NCS: OutputPin<Error = core::convert::Infallible>,
     TIM: CountDown,
 {
     /// Initialize stream, send RDATAC command
-    pub fn init(mut ads1292: Ads1292<SPI, NCS, TIM>) -> Result<Self, E, EO> {
+    pub fn init(mut ads1292: Ads1292<SPI, NCS, TIM>) -> Result<Self, E> {
         ads1292.cmd(Command::RDATAC)?;
         Ok(Self { ads1292 })
     }
 
     /// Send SDATAC command, then return wrapped ADS1292
-    pub fn into_inner(mut self) -> Result<Ads1292<SPI, NCS, TIM>, E, EO> {
+    pub fn into_inner(mut self) -> Result<Ads1292<SPI, NCS, TIM>, E> {
         self.ads1292.cmd(Command::SDATAC)?;
         Ok(self.ads1292)
     }
 }
 
-impl<SPI, NCS, TIM, E, EO> Iterator for Ads1292DataStream<SPI, NCS, TIM, E, EO>
+impl<SPI, NCS, TIM, E> Iterator for Ads1292DataStream<SPI, NCS, TIM, E>
 where
     SPI: bspi::Transfer<u8, Error = E> + bspi::Write<u8, Error = E>,
-    NCS: OutputPin<Error = EO>,
+    NCS: OutputPin<Error = core::convert::Infallible>,
     TIM: CountDown,
 {
-    type Item = Result<Ads1292Data, E, EO>;
+    type Item = Result<Ads1292Data, E>;
     fn next(&mut self) -> Option<Self::Item> {
         let mut buf = [0u8; 9];
         Some(

--- a/src/ads1292/mod.rs
+++ b/src/ads1292/mod.rs
@@ -46,8 +46,10 @@ where
     pub fn read_data(&mut self) -> Result<Ads1292Data, E, EO> {
         // Send Read command
         self.cmd(Command::RDATA)?;
+        let mut buf = [0u8; 9];
         // Receive data
-        self.read()
+        self.spi.transfer(&mut buf)?;
+        Ok(buf.into())
     }
 
     /// Read a single data block without sending the RDATA command first

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,27 +1,17 @@
 use embedded_hal::blocking::spi as bspi;
 use embedded_hal::digital::v2::OutputPin;
 use embedded_hal::timer::CountDown;
-
 use embedded_hal::spi as eh_spi;
+
+fn infallible<T>(r: core::result::Result<T, core::convert::Infallible>) -> T {
+    match r {
+        Ok(x) => x,
+        Err(never) => match never {},
+    }
+}
 
 /// SPI mode
 pub const MODE: eh_spi::Mode = eh_spi::MODE_1;
-
-#[derive(Debug, Copy, Clone)]
-pub enum SpiError<E, E2> {
-    /// SPI bus I/O error
-    BusError(E),
-    /// Error setting the nCS pin
-    NCSError(E2),
-    /// An error occurred whilst waiting
-    WaitError,
-}
-
-impl<E, E2> core::convert::From<E> for SpiError<E, E2> {
-    fn from(error: E) -> Self {
-        SpiError::BusError(error)
-    }
-}
 
 /// A SPI device also triggering the nCS-pin when suited.
 pub struct SpiDevice<SPI, NCS, TIM> {
@@ -33,30 +23,28 @@ pub struct SpiDevice<SPI, NCS, TIM> {
     timer: TIM,
 }
 
-impl<SPI, NCS, TIM, E, EO> SpiDevice<SPI, NCS, TIM>
+impl<SPI, NCS, TIM, E> SpiDevice<SPI, NCS, TIM>
 where
     SPI: bspi::Write<u8, Error = E> + bspi::Transfer<u8, Error = E>,
-    NCS: OutputPin<Error = EO>,
+    NCS: OutputPin<Error = core::convert::Infallible>,
     TIM: CountDown,
 {
     /// Create a new SPI device
-    pub fn new(spi: SPI, mut ncs: NCS, timer: TIM) -> Result<Self, SpiError<E, EO>> {
-        ncs.set_high().map_err(SpiError::NCSError)?;
+    pub fn new(spi: SPI, mut ncs: NCS, timer: TIM) -> Self {
+        infallible(ncs.set_high());
 
-        Ok(SpiDevice { spi, ncs, timer })
+        SpiDevice { spi, ncs, timer }
     }
 
     /// Transfer the buffer to the device, the passed buffer will contain the read data.
     #[inline]
-    pub fn transfer(&mut self, buffer: &mut [u8]) -> Result<(), SpiError<E, EO>> {
-        self.ncs.set_low().map_err(SpiError::NCSError)?;
-        let res = (|| {
-            self.wait(20)?;
-            self.spi.transfer(buffer)?;
-            self.wait(20)
-        })();
-        self.ncs.set_high().map_err(SpiError::NCSError)?;
-        self.wait(10)?;
+    pub fn transfer(&mut self, buffer: &mut [u8]) -> Result<(), E> {
+        infallible(self.ncs.set_low());
+        self.wait(20);
+        let res = self.spi.transfer(buffer);
+        self.wait(20);
+        infallible(self.ncs.set_high());
+        self.wait(10);
         res?; // Drop out of function with SPIError only after setting NCS.
         Ok(())
     }
@@ -66,32 +54,29 @@ where
     /// that are usually necessary when communicating with the ADS1292 device. Use a delay of at
     /// least 50 microseconds between uses of this and other spi transfer and write functions.
     #[inline]
-    pub unsafe fn unsafe_transfer(&mut self, buffer: &mut [u8]) -> Result<(), SpiError<E, EO>> {
-        self.ncs.set_low().map_err(SpiError::NCSError)?;
+    pub unsafe fn unsafe_transfer(&mut self, buffer: &mut [u8]) -> Result<(), E> {
+        infallible(self.ncs.set_low());
         let res = self.spi.transfer(buffer);
-        self.ncs.set_high().map_err(SpiError::NCSError)?;
+        infallible(self.ncs.set_high());
         res?; // Drop out of function with SPIError only after setting NCS.
         Ok(())
     }
 
     /// Write a number of bytes to the device.
     #[inline]
-    pub fn write(&mut self, buffer: &[u8]) -> Result<(), SpiError<E, EO>> {
-        self.ncs.set_low().map_err(SpiError::NCSError)?;
-        let res = (|| {
-            self.wait(20)?;
-            self.spi.write(buffer)?;
-            self.wait(20)
-        })();
-        self.ncs.set_high().map_err(SpiError::NCSError)?;
-        self.wait(10)?;
-
+    pub fn write(&mut self, buffer: &[u8]) -> Result<(), E> {
+        infallible(self.ncs.set_low());
+        self.wait(20);
+        let res = self.spi.write(buffer);
+        self.wait(20);
+        infallible(self.ncs.set_high());
+        self.wait(10);
         res?; // Drop out of function with SPIError only after setting NCS.
         Ok(())
     }
 
-    pub fn wait(&mut self, i: u16) -> Result<(), SpiError<E, EO>> {
-        crate::util::wait(&mut self.timer, i).map_err(|_| SpiError::WaitError)
+    pub fn wait(&mut self, i: u16) {
+        crate::util::wait(&mut self.timer, i);
     }
 
     /// Consume self and release inner resources.

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,11 +1,12 @@
 use embedded_hal::timer::CountDown;
-use nb::{block, Result};
-use void::Void;
+use nb::block;
 
 /// Blockingly wait i clock overflows.
-pub fn wait<TIM: CountDown>(timer: &mut TIM, i: u16) -> Result<(), Void> {
+pub fn wait<TIM: CountDown>(timer: &mut TIM, i: u16) {
     for _ in 0..i {
-        block!(timer.wait())?;
+        match block!(timer.wait()) {
+            Ok(()) => (),
+            Err(never) => match never {},
+        }
     }
-    Ok(())
 }


### PR DESCRIPTION
This also fixes an issue where the Ads129xx constructor can fail and lose the references to the underlying peripherals.